### PR TITLE
Change react-tilt to react-tilting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "0.0.0",
       "dependencies": {
         "@emailjs/browser": "^3.10.0",
-        "@react-three/drei": "^9.56.24",
-        "@react-three/fiber": "^8.11.1",
-        "framer-motion": "^9.0.7",
-        "maath": "^0.5.2",
+        "@react-three/drei": "^9.57.3",
+        "@react-three/fiber": "^8.12.0",
+        "framer-motion": "^10.3.2",
+        "maath": "^0.5.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.8.1",
-        "react-tilt": "^0.1.4",
+        "react-router-dom": "^6.9.0",
+        "react-tilting": "^0.1.6",
         "react-vertical-timeline-component": "^3.6.0",
-        "three": "^0.149.0"
+        "three": "^0.150.1"
       },
       "devDependencies": {
-        "@types/react": "^18.0.27",
-        "@types/react-dom": "^18.0.10",
+        "@types/react": "^18.0.28",
+        "@types/react-dom": "^18.0.11",
         "@vitejs/plugin-react": "^3.1.0",
-        "autoprefixer": "^10.4.13",
+        "autoprefixer": "^10.4.14",
         "postcss": "^8.4.21",
-        "tailwindcss": "^3.2.6",
-        "vite": "^4.1.0"
+        "tailwindcss": "^3.2.7",
+        "vite": "^4.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -65,21 +65,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
-      "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
+      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.0",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-module-transforms": "^7.21.0",
+        "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.0",
+        "@babel/parser": "^7.21.3",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0",
+        "@babel/traverse": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -95,12 +95,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.1.tgz",
-      "integrity": "sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
+      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.0",
+        "@babel/types": "^7.21.3",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
+      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -363,19 +363,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.2.tgz",
-      "integrity": "sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
+      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.1",
+        "@babel/generator": "^7.21.3",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.2",
-        "@babel/types": "^7.21.2",
+        "@babel/parser": "^7.21.3",
+        "@babel/types": "^7.21.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.2.tgz",
-      "integrity": "sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==",
+      "version": "7.21.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
+      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -398,33 +398,33 @@
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.4.2.tgz",
-      "integrity": "sha512-0+4bNjlndNWMoVLH/+y4uHnf6GrTipsC+YTppJxelVJo+xeRVQ0s2PpkdDCVTsu7efyj+8r1gFiwVXsp6JZ0iQ==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
       "dependencies": {
-        "@chevrotain/gast": "10.4.2",
-        "@chevrotain/types": "10.4.2",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
         "lodash": "4.17.21"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.4.2.tgz",
-      "integrity": "sha512-4ZAn8/mjkmYonilSJ60gGj1tAF0cVWYUMlIGA0e4ATAc3a648aCnvpBw7zlPHDQjFp50XC13iyWEgWAKiRKTOA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
       "dependencies": {
-        "@chevrotain/types": "10.4.2",
+        "@chevrotain/types": "10.5.0",
         "lodash": "4.17.21"
       }
     },
     "node_modules/@chevrotain/types": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.4.2.tgz",
-      "integrity": "sha512-QzSCjg6G4MvIoLeIgOiMR0IgzkGEQqrNJJIr3T5ETRa7l4Av4AMIiEctV99mvDr57iXwwk0/kr3RJxiU36Nevw=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
     },
     "node_modules/@chevrotain/utils": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.4.2.tgz",
-      "integrity": "sha512-V34dacxWLwKcvcy32dx96ADJVdB7kOJLm7LyBkBQw5u5HC9WdEFw2G17zml+U3ivavGTrGPJHl8o9/UJm0PlUw=="
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
     },
     "node_modules/@emailjs/browser": {
       "version": "3.10.0",
@@ -952,15 +952,15 @@
       "integrity": "sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q=="
     },
     "node_modules/@react-three/drei": {
-      "version": "9.56.27",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.56.27.tgz",
-      "integrity": "sha512-NnhzBOagyd/PDWTo/BGu315e9ubUjvbeIKjJwkDBtjOnv4SpUsvAm0H9yxLSHBOXQ24Mik3Y3zETBd0+dHD5Ew==",
+      "version": "9.57.3",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.57.3.tgz",
+      "integrity": "sha512-zkkrIrd3kuKkRlT0IUg6y8dBppZiv2KXrS6IzUIOKAAwbsNAotAQT//0u6Z242q0WdSfxiQgPFi3WApKpbENPw==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@react-spring/three": "~9.6.1",
         "@use-gesture/react": "^10.2.24",
-        "camera-controls": "^2.1.0",
-        "detect-gpu": "^5.0.10",
+        "camera-controls": "^2.3.1",
+        "detect-gpu": "^5.0.14",
         "glsl-noise": "^0.0.0",
         "lodash.clamp": "^4.0.3",
         "lodash.omit": "^4.5.0",
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/@react-three/fiber": {
-      "version": "8.11.5",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.11.5.tgz",
-      "integrity": "sha512-Z+/hNPDy71q7xiGQQwngpLhoyjqPsuObs/Wbk2nYDZ0SC6rg3nCQBcIR6cf1+ONx1EP53L5lbuxcr+chkdGGmQ==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.12.0.tgz",
+      "integrity": "sha512-o6DkNtNHqcOFRbxaiY5xayelE/9+Z0z9wWu5awqjVbc0c/1QM6AttJH6rKW0U/O6LWxSfxDTARXVzknZqpDJ7A==",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -1031,9 +1031,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.2.tgz",
-      "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==",
       "engines": {
         "node": ">=14"
       }
@@ -1079,6 +1079,21 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/three": {
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.149.0.tgz",
+      "integrity": "sha512-fgNBm9LWc65ER/W0cvoXdC0iMy7Ke9e2CONmEr6Jt8sDSY3sw4DgOubZfmdZ747dkPhbQrgRQAWwDEr2S/7IEg==",
+      "peer": true,
+      "dependencies": {
+        "@types/webxr": "*"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.1.tgz",
+      "integrity": "sha512-xlFXPfgJR5vIuDefhaHuUM9uUgvPaXB6GKdXy2gdEh8gBWQZ2ul24AJz3foUd8NNKlSTQuWYJpCb1/pL81m1KQ==",
+      "peer": true
     },
     "node_modules/@use-gesture/core": {
       "version": "10.2.24",
@@ -1184,9 +1199,9 @@
       "dev": true
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "dev": true,
       "funding": [
         {
@@ -1199,8 +1214,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -1283,17 +1298,17 @@
       }
     },
     "node_modules/camera-controls": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.3.1.tgz",
-      "integrity": "sha512-mGPDOqCTSUqaeX3yR3bWQ/p1M5CR8C+cnqndBxQugfGKysn1dhRtw8Q6sG1hq4GL8RPsGwRanwQk5zwQjyrxyQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.3.2.tgz",
+      "integrity": "sha512-wCqg6Hf4RTMlambHB7gxmwo4aJk7seQ5w42ZXeRWAmVFcz1Gn25UpWr9CjlEC6+ghuTCghn1VeQZrIta2ZDFCA==",
       "peerDependencies": {
         "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001457",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz",
-      "integrity": "sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==",
+      "version": "1.0.30001466",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001466.tgz",
+      "integrity": "sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==",
       "dev": true,
       "funding": [
         {
@@ -1321,14 +1336,14 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.4.2.tgz",
-      "integrity": "sha512-gzF5GxE0Ckti5kZVuKEZycLntB5X2aj9RVY0r4/220GwQjdnljU+/t3kP74/FMWC7IzCDDEjQ9wsFUf0WCdSHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
+      "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "10.4.2",
-        "@chevrotain/gast": "10.4.2",
-        "@chevrotain/types": "10.4.2",
-        "@chevrotain/utils": "10.4.2",
+        "@chevrotain/cst-dts-gen": "10.5.0",
+        "@chevrotain/gast": "10.5.0",
+        "@chevrotain/types": "10.5.0",
+        "@chevrotain/utils": "10.5.0",
         "lodash": "4.17.21",
         "regexp-to-ast": "0.5.0"
       }
@@ -1447,9 +1462,9 @@
       }
     },
     "node_modules/detect-gpu": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.12.tgz",
-      "integrity": "sha512-HRI2Ci3hwfu9wtAikHpQ5MiGu3I7YDuWXshvkRtwCBAS2tYVqGd7x0fRzA19YjYgRXO6RFW5Yaf8o/xGYTojjg==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.15.tgz",
+      "integrity": "sha512-ImImgPRhTvo/bmtotR1KG534ZE+L6yIV9sMe4y3zOUzeInnYk/9KOBqxz9M5hKkHXhGKKjY04pMrLMb+rp3FWw==",
       "dependencies": {
         "webgl-constants": "^1.1.1"
       }
@@ -1489,9 +1504,9 @@
       "integrity": "sha512-+3NaRjWktb5r61ZFoDejlykPEFKT5N/LkbXsaddlw6xNSXBanUYpFc2AXXpbJDilPHazcSreU/DpQIaxfX0NfQ=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.311",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.311.tgz",
-      "integrity": "sha512-RoDlZufvrtr2Nx3Yx5MB8jX3aHIxm8nRWPJm3yVvyHmyKaRvn90RjzB6hNnt0AkhS3IInJdyRfQb4mWhPvUjVw==",
+      "version": "1.4.330",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.330.tgz",
+      "integrity": "sha512-PqyefhybrVdjAJ45HaPLtuVaehiSw7C3ya0aad+rvmV53IVyXmYRk3pwIOb2TxTDTnmgQdn46NjMMaysx79/6Q==",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -1617,9 +1632,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-9.1.7.tgz",
-      "integrity": "sha512-nKxBkIO4IPkMEqcBbbATxsVjwPYShKl051yhBv9628iAH6JLeHD0siBHxkL62oQzMC1+GNX73XtPjgP753ufuw==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.3.2.tgz",
+      "integrity": "sha512-8GrK3X2vXG/9LJCNJuU5gKxDwSN0VTf7tD6MFP3S9F7rgsUavx+8ZNwhfZfak6maCBBHZ1m86K7TIXpbdfML2w==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -1629,6 +1644,14 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fsevents": {
@@ -1762,9 +1785,9 @@
       }
     },
     "node_modules/its-fine": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.0.9.tgz",
-      "integrity": "sha512-Ph+vcp1R100JOM4raXmDx/wCTi4kMkMXiFE108qGzsLdghXFPqad82UJJtqT1jwdyWYkTU6eDpDnol/ZIzW+1g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.1.0.tgz",
+      "integrity": "sha512-nEoEt5EYSed1mmvwCRv3l1+6T7pyu4ltyBihzPjUtaSWhFhUPU/c7xkPDIutTh8FeIv0F1F5wOFYI8a2s5rlBA==",
       "dependencies": {
         "@types/react-reconciler": "^0.28.0"
       },
@@ -1815,9 +1838,9 @@
       "integrity": "sha512-MK3FOody4TXbFf8Yqv7EBbySw7aPvEcPX++Ipt6Sox+/YMFvR5xaTyhfNSk1AEmMy+RYIw81ctN4IMxCB8OAlg=="
     },
     "node_modules/lilconfig": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -1864,9 +1887,9 @@
       }
     },
     "node_modules/maath": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/maath/-/maath-0.5.2.tgz",
-      "integrity": "sha512-MFjfnXF5CzZaVnBuKc9y1FJh/BiPGqf19NH8Jm4o/jKTxuQ3RyPkcSIpuwdDhXrWROVKAxi3KjmHFUNMuIndbg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.5.3.tgz",
+      "integrity": "sha512-ut63A4zTd9abtpi+sOHW1fPWPtAFrjK0E17eAthx1k93W/T2cWLKV5oaswyotJVDvvW1EXSdokAqhK5KOu0Qdw==",
       "peerDependencies": {
         "@types/three": ">=0.144.0",
         "three": ">=0.144.0"
@@ -2298,11 +2321,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.1.tgz",
-      "integrity": "sha512-Jgi8BzAJQ8MkPt8ipXnR73rnD7EmZ0HFFb7jdQU24TynGW1Ooqin2KVDN9voSC+7xhqbbCd2cjGUepb6RObnyg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
       "dependencies": {
-        "@remix-run/router": "1.3.2"
+        "@remix-run/router": "1.4.0"
       },
       "engines": {
         "node": ">=14"
@@ -2312,12 +2335,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.1.tgz",
-      "integrity": "sha512-67EXNfkQgf34P7+PSb6VlBuaacGhkKn3kpE51+P6zYSG2kiRoumXEL6e27zTa9+PGF2MNXbgIUHTVlleLbIcHQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
       "dependencies": {
-        "@remix-run/router": "1.3.2",
-        "react-router": "6.8.1"
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
       },
       "engines": {
         "node": ">=14"
@@ -2327,13 +2350,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/react-tilt": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/react-tilt/-/react-tilt-0.1.4.tgz",
-      "integrity": "sha512-bVeRumg+RIn6QN8S92UmubGqX/BG6/QeQISBeAcrS/70dpo/jVj+sjikIawDl5wTuPdubFH8zH0EMulWIctsnw==",
+    "node_modules/react-tilting": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/react-tilting/-/react-tilting-0.1.6.tgz",
+      "integrity": "sha512-FY7DQhmj3YmJfhMAw/Dl0RbrseEPlf97aMGrgexwr6KYVli/vxCm+RQOxzkeZTDN0X75YV5ACH1BcgFeU/NPdw==",
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0-beta || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0-beta || ^16.0.0"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/react-use-measure": {
@@ -2426,9 +2449,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.17.2.tgz",
-      "integrity": "sha512-qMNZdlQPCkWodrAZ3qnJtvCAl4vpQ8q77uEujVCCbC/6CLB7Lcmvjq7HyiOSnf4fxTT9XgsE36oLHJBH49xjqA==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.19.1.tgz",
+      "integrity": "sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2580,9 +2603,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.149.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.149.0.tgz",
-      "integrity": "sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ=="
+      "version": "0.150.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.150.1.tgz",
+      "integrity": "sha512-5C1MqKUWaHYo13BX0Q64qcdwImgnnjSOFgBscOzAo8MYCzEtqfQqorEKMcajnA3FHy1yVlIe9AmaMQ0OQracNA=="
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.5.23",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "3dfolio",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -10,24 +10,24 @@
   },
   "dependencies": {
     "@emailjs/browser": "^3.10.0",
-    "@react-three/drei": "^9.56.24",
-    "@react-three/fiber": "^8.11.1",
-    "framer-motion": "^9.0.7",
-    "maath": "^0.5.2",
+    "@react-three/drei": "^9.57.3",
+    "@react-three/fiber": "^8.12.0",
+    "framer-motion": "^10.3.2",
+    "maath": "^0.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.8.1",
-    "react-tilt": "^0.1.4",
+    "react-router-dom": "^6.9.0",
+    "react-tilting": "^0.1.6",
     "react-vertical-timeline-component": "^3.6.0",
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   },
   "devDependencies": {
-    "@types/react": "^18.0.27",
-    "@types/react-dom": "^18.0.10",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^3.1.0",
-    "autoprefixer": "^10.4.13",
+    "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",
-    "tailwindcss": "^3.2.6",
-    "vite": "^4.1.0"
+    "tailwindcss": "^3.2.7",
+    "vite": "^4.1.4"
   }
 }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import Tilt from "react-tilting";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import Tilt from "react-tilting";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";


### PR DESCRIPTION
This change removes the need to use --legacy-peer-deps and allows the latest React version to be used in the project along with updated libraries.