### PR TITLE
Update when importing Tilt from react-tilt

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import {Tilt} from "react-tilt";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import {Tilt} from "react-tilt";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";


### PR DESCRIPTION
I got syntax error when importing Tilt

_Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/react-tilt.js?v=5c5d06cb' does not provide an export named 'default' (at Works.jsx:2:8)_


to fix I added {} to Tilt:
`import {Tilt} from 'react-tilt'
`