### PR TITLE
fix: Resolve React Tilt Version Conflict and Import Issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.1",
-        "react-tilt": "^0.1.4",
+        "react-tilt": "^1.0.2",
         "react-vertical-timeline-component": "^3.6.0",
         "three": "^0.149.0"
       },
@@ -1049,9 +1049,9 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "18.0.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
-      "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
+      "version": "18.2.48",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.48.tgz",
+      "integrity": "sha512-qboRCl6Ie70DQQG9hhNREz81jqC1cs9EVNcjQ1AU+jH6NFfSAhVVbrrY/+nSF+Bsk4AOwm9Qa61InvMCyV+H3w==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1062,7 +1062,6 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1079,6 +1078,30 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
+      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ==",
+      "peer": true
+    },
+    "node_modules/@types/three": {
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==",
+      "peer": true,
+      "dependencies": {
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.11.tgz",
+      "integrity": "sha512-bo3K4UFBwP1RbMjuMin9cgyThD5YxjIWjQHJT7O7PVU2DB81qop7JnZAXRmrrGPbEsoHcdUmjmQDXI6zfqkVIQ==",
+      "peer": true
     },
     "node_modules/@use-gesture/core": {
       "version": "10.2.24",
@@ -1901,6 +1924,12 @@
         "three": ">=0.137"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "peer": true
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -2328,12 +2357,14 @@
       }
     },
     "node_modules/react-tilt": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/react-tilt/-/react-tilt-0.1.4.tgz",
-      "integrity": "sha512-bVeRumg+RIn6QN8S92UmubGqX/BG6/QeQISBeAcrS/70dpo/jVj+sjikIawDl5wTuPdubFH8zH0EMulWIctsnw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-tilt/-/react-tilt-1.0.2.tgz",
+      "integrity": "sha512-21tUUsmuw5id/6NDtKqwYTG4taVnw+BoUwIG6YsgPC9GI6cx4BnBuSqgriQYAYcv3bdGNzecaBL+rvQRAm28bg==",
       "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0-beta || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0-beta || ^16.0.0"
+        "@types/react": "^18.0.29",
+        "@types/react-dom": "^18.0.11",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/react-use-measure": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",
-    "react-tilt": "^0.1.4",
+    "react-tilt": "^1.0.2",
     "react-vertical-timeline-component": "^3.6.0",
     "three": "^0.149.0"
   },

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,5 +1,6 @@
 import React from "react";
-import Tilt from "react-tilt";
+import { Tilt } from 'react-tilt'
+
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";

--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import { Tilt } from 'react-tilt'
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";


### PR DESCRIPTION
Addresses two issues:
1. Updates react-tilt version to 1.0.2 to resolve dependency conflicts.
2. Fixes import statement in About component to prevent Rollup resolution errors.