### PR TITLE
Update About.jsx

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Tilt from "react-tilt";
+import { Tilt } from "react-tilt";
 import { motion } from "framer-motion";
 
 import { styles } from "../styles";


### PR DESCRIPTION
the current import section looks like : import Tilt from "react-tilt";we are facing this issue:
Uncaught SyntaxError: The requested module '/node_modules/.vite/deps/react-tilt.js?v=e9c1a88c' does not provide an export named 'default' (at About.jsx:2:8)

As per : https://www.npmjs.com/package/react-tilt

And using this, I was able to resolve this issue:
import { Tilt } from 'react-tilt'